### PR TITLE
making the short hash used by the pipeline be a hash of HEAD 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate Short Commit SHA
         id: vars
         run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          calculatedSha=$(git rev-parse --short HEAD)
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
 
       - name: Display Short Commit SHA


### PR DESCRIPTION
This has been bugging me. The workflow runs keep generating short SHA tags on the reports in Heimdall that don't actually match the commit hash short SHAs of the commit that triggered the run.